### PR TITLE
core/vm, params: EIP-1108 Reduce alt_bn128 precompile gas costs

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -48,7 +48,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			precompiles = PrecompiledContractsByzantium
 		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
-			return RunPrecompiledContract(p, input, contract)
+			return RunPrecompiledContract(evm, p, input, contract)
 		}
 	}
 	for _, interpreter := range evm.interpreters {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -62,18 +62,22 @@ const (
 
 	// Precompiled contract gas prices
 
-	EcrecoverGas            uint64 = 3000   // Elliptic curve sender recovery gas price
-	Sha256BaseGas           uint64 = 60     // Base price for a SHA256 operation
-	Sha256PerWordGas        uint64 = 12     // Per-word price for a SHA256 operation
-	Ripemd160BaseGas        uint64 = 600    // Base price for a RIPEMD160 operation
-	Ripemd160PerWordGas     uint64 = 120    // Per-word price for a RIPEMD160 operation
-	IdentityBaseGas         uint64 = 15     // Base price for a data copy operation
-	IdentityPerWordGas      uint64 = 3      // Per-work price for a data copy operation
-	ModExpQuadCoeffDiv      uint64 = 20     // Divisor for the quadratic particle of the big int modular exponentiation
-	Bn256AddGas             uint64 = 500    // Gas needed for an elliptic curve addition
-	Bn256ScalarMulGas       uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
-	Bn256PairingBaseGas     uint64 = 100000 // Base price for an elliptic curve pairing check
-	Bn256PairingPerPointGas uint64 = 80000  // Per-point price for an elliptic curve pairing check
+	EcrecoverGas                     uint64 = 3000   // Elliptic curve sender recovery gas price
+	Sha256BaseGas                    uint64 = 60     // Base price for a SHA256 operation
+	Sha256PerWordGas                 uint64 = 12     // Per-word price for a SHA256 operation
+	Ripemd160BaseGas                 uint64 = 600    // Base price for a RIPEMD160 operation
+	Ripemd160PerWordGas              uint64 = 120    // Per-word price for a RIPEMD160 operation
+	IdentityBaseGas                  uint64 = 15     // Base price for a data copy operation
+	IdentityPerWordGas               uint64 = 3      // Per-work price for a data copy operation
+	ModExpQuadCoeffDiv               uint64 = 20     // Divisor for the quadratic particle of the big int modular exponentiation
+	Bn256AddGas                      uint64 = 500    // Gas needed for an elliptic curve addition
+	Bn256ScalarMulGas                uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
+	Bn256PairingBaseGas              uint64 = 100000 // Base price for an elliptic curve pairing check
+	Bn256PairingPerPointGas          uint64 = 80000  // Per-point price for an elliptic curve pairing check
+	OptimizedBn256AddGas             uint64 = 50     // Gas needed for an elliptic curve addition using optimized Cloudflare’s bn256 library
+	OptimizedBn256ScalarMulGas       uint64 = 2000   // Gas needed for an elliptic curve scalar multiplication using optimized Cloudflare’s bn256 library
+	OptimizedBn256PairingBaseGas     uint64 = 80000  // Base price for an elliptic curve pairing check using optimized Cloudflare’s bn256 library
+	OptimizedBn256PairingPerPointGas uint64 = 5000   // Per-point price for an elliptic curve pairing check using optimized Cloudflare’s bn256 library
 )
 
 var (


### PR DESCRIPTION
This PR implements [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108).
Reduce `alt_bn128` precompile gas costs and make sure they are enabled with Constantinople hard fork