### PR TITLE
core/vm, params: EIP-1108 Reduce alt_bn128 precompile gas costs

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -59,6 +59,19 @@ var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}): &bn256Pairing{},
 }
 
+// PrecompiledContractsConstantinople contains the default set of pre-compiled Ethereum
+// contracts used in the Constantinople release.
+var PrecompiledContractsConstantinople = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}): &ecrecover{},
+	common.BytesToAddress([]byte{2}): &sha256hash{},
+	common.BytesToAddress([]byte{3}): &ripemd160hash{},
+	common.BytesToAddress([]byte{4}): &dataCopy{},
+	common.BytesToAddress([]byte{5}): &bigModExp{},
+	common.BytesToAddress([]byte{6}): &optimizedBn256Add{},
+	common.BytesToAddress([]byte{7}): &optimizedBn256ScalarMul{},
+	common.BytesToAddress([]byte{8}): &optimizedBn256Pairing{},
+}
+
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
 func RunPrecompiledContract(p PrecompiledContract, input []byte, contract *Contract) (ret []byte, err error) {
 	gas := p.RequiredGas(input)
@@ -273,10 +286,15 @@ func newTwistPoint(blob []byte) (*bn256.G2, error) {
 
 // bn256Add implements a native elliptic curve point addition.
 type bn256Add struct{}
+type optimizedBn256Add struct{ bn256Add }
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256Add) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGas
+}
+
+func (c *optimizedBn256Add) RequiredGas(input []byte) uint64 {
+	return params.OptimizedBn256AddGas
 }
 
 func (c *bn256Add) Run(input []byte) ([]byte, error) {
@@ -295,10 +313,15 @@ func (c *bn256Add) Run(input []byte) ([]byte, error) {
 
 // bn256ScalarMul implements a native elliptic curve scalar multiplication.
 type bn256ScalarMul struct{}
+type optimizedBn256ScalarMul struct{ bn256ScalarMul }
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256ScalarMul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGas
+}
+
+func (c *optimizedBn256ScalarMul) RequiredGas(input []byte) uint64 {
+	return params.OptimizedBn256ScalarMulGas
 }
 
 func (c *bn256ScalarMul) Run(input []byte) ([]byte, error) {
@@ -324,10 +347,15 @@ var (
 
 // bn256Pairing implements a pairing pre-compile for the bn256 curve
 type bn256Pairing struct{}
+type optimizedBn256Pairing struct{ bn256Pairing }
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGas + uint64(len(input)/192)*params.Bn256PairingPerPointGas
+}
+
+func (c *optimizedBn256Pairing) RequiredGas(input []byte) uint64 {
+	return params.OptimizedBn256PairingBaseGas + uint64(len(input)/192)*params.OptimizedBn256PairingPerPointGas
 }
 
 func (c *bn256Pairing) Run(input []byte) ([]byte, error) {

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -337,7 +337,7 @@ var bn256PairingTests = []precompiledTest{
 }
 
 func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
-	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
+	p := PrecompiledContractsConstantinople[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
 		nil, new(big.Int), p.RequiredGas(in))
@@ -354,7 +354,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 	if test.noBenchmark {
 		return
 	}
-	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
+	p := PrecompiledContractsConstantinople[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	reqGas := p.RequiredGas(in)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -47,6 +47,9 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 		if evm.ChainConfig().IsByzantium(evm.BlockNumber) {
 			precompiles = PrecompiledContractsByzantium
 		}
+		if evm.ChainConfig().IsConstantinople(evm.BlockNumber) {
+			precompiles = PrecompiledContractsConstantinople
+		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
 			return RunPrecompiledContract(p, input, contract)
 		}
@@ -182,6 +185,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		precompiles := PrecompiledContractsHomestead
 		if evm.ChainConfig().IsByzantium(evm.BlockNumber) {
 			precompiles = PrecompiledContractsByzantium
+		}
+		if evm.ChainConfig().IsConstantinople(evm.BlockNumber) {
+			precompiles = PrecompiledContractsConstantinople
 		}
 		if precompiles[addr] == nil && evm.ChainConfig().IsEIP158(evm.BlockNumber) && value.Sign() == 0 {
 			// Calling a non existing account, don't do anything, but ping the tracer

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -62,18 +62,22 @@ const (
 
 	// Precompiled contract gas prices
 
-	EcrecoverGas            uint64 = 3000   // Elliptic curve sender recovery gas price
-	Sha256BaseGas           uint64 = 60     // Base price for a SHA256 operation
-	Sha256PerWordGas        uint64 = 12     // Per-word price for a SHA256 operation
-	Ripemd160BaseGas        uint64 = 600    // Base price for a RIPEMD160 operation
-	Ripemd160PerWordGas     uint64 = 120    // Per-word price for a RIPEMD160 operation
-	IdentityBaseGas         uint64 = 15     // Base price for a data copy operation
-	IdentityPerWordGas      uint64 = 3      // Per-work price for a data copy operation
-	ModExpQuadCoeffDiv      uint64 = 20     // Divisor for the quadratic particle of the big int modular exponentiation
-	Bn256AddGas             uint64 = 500    // Gas needed for an elliptic curve addition
-	Bn256ScalarMulGas       uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
-	Bn256PairingBaseGas     uint64 = 100000 // Base price for an elliptic curve pairing check
-	Bn256PairingPerPointGas uint64 = 80000  // Per-point price for an elliptic curve pairing check
+	EcrecoverGas                     uint64 = 3000   // Elliptic curve sender recovery gas price
+	Sha256BaseGas                    uint64 = 60     // Base price for a SHA256 operation
+	Sha256PerWordGas                 uint64 = 12     // Per-word price for a SHA256 operation
+	Ripemd160BaseGas                 uint64 = 600    // Base price for a RIPEMD160 operation
+	Ripemd160PerWordGas              uint64 = 120    // Per-word price for a RIPEMD160 operation
+	IdentityBaseGas                  uint64 = 15     // Base price for a data copy operation
+	IdentityPerWordGas               uint64 = 3      // Per-work price for a data copy operation
+	ModExpQuadCoeffDiv               uint64 = 20     // Divisor for the quadratic particle of the big int modular exponentiation
+	Bn256AddGas                      uint64 = 500    // Gas needed for an elliptic curve addition
+	Bn256ScalarMulGas                uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
+	Bn256PairingBaseGas              uint64 = 100000 // Base price for an elliptic curve pairing check
+	Bn256PairingPerPointGas          uint64 = 80000  // Per-point price for an elliptic curve pairing check
+	OptimizedBn256AddGas             uint64 = 50     // Gas needed for an elliptic curve addition using optimized Cloudflare’s bn256 library
+	OptimizedBn256ScalarMulGas       uint64 = 2000   // Gas needed for an elliptic curve scalar multiplication using optimized Cloudflare’s bn256 library
+	OptimizedBn256PairingBaseGas     uint64 = 80000  // Base price for an elliptic curve pairing check using optimized Cloudflare’s bn256 library
+	OptimizedBn256PairingPerPointGas uint64 = 5000   // Per-point price for an elliptic curve pairing check using optimized Cloudflare’s bn256 library
 )
 
 var (


### PR DESCRIPTION
Improved implementation of [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108).
Reduce `alt_bn128` precompile gas costs and make sure they are enabled with Constantinople hard fork